### PR TITLE
[FIX] : 🐛 AccentColor.colorset 복구

### DIFF
--- a/ECWeather/Resource/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ECWeather/Resource/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
`ECWeather/Resource/Assets.xcassets: Accent color ‘AccentColor’ is not present in any asset catalogs.`
실행할때마다 경고 떠서 AccentColor.colorset 파일 돌려놨습니다 ㅜ
